### PR TITLE
Bind the boot chain to the ABL it was derived from

### DIFF
--- a/ablrepo/CPH2767/abl.meta
+++ b/ablrepo/CPH2767/abl.meta
@@ -1,0 +1,7 @@
+product=CPH2767
+model=unknown
+soc=unknown
+abl_version=unknown
+sha256=01c6f792f51a19583b65e895b789bf4a66892fe56b27babb4da2bcdee94a122b
+bytes=278528
+codename=macan

--- a/ablrepo/CPH2841/abl.meta
+++ b/ablrepo/CPH2841/abl.meta
@@ -1,0 +1,7 @@
+product=CPH2841
+model=unknown
+soc=unknown
+abl_version=unknown
+sha256=0d8aa124c40348362108109890cdc25a4f3cd8f7351c1007e15d6fdbb6ed7c5f
+bytes=278528
+same_image_as=OPD2513,PLR110,PMA120

--- a/ablrepo/OPD2513/abl.meta
+++ b/ablrepo/OPD2513/abl.meta
@@ -1,0 +1,7 @@
+product=OPD2513
+model=unknown
+soc=unknown
+abl_version=unknown
+sha256=0d8aa124c40348362108109890cdc25a4f3cd8f7351c1007e15d6fdbb6ed7c5f
+bytes=278528
+same_image_as=CPH2841,PLR110,PMA120

--- a/ablrepo/PLK110/abl.meta
+++ b/ablrepo/PLK110/abl.meta
@@ -1,0 +1,6 @@
+product=PLK110
+model=unknown
+soc=unknown
+abl_version=unknown
+sha256=477bf550d414605052858dd97dc2cddf68f676bf5f7fe9b431f5f85a8b7ec379
+bytes=278328

--- a/ablrepo/PLR110/abl.meta
+++ b/ablrepo/PLR110/abl.meta
@@ -1,0 +1,8 @@
+product=PLR110
+model=unknown
+soc=unknown
+abl_version=unknown
+sha256=0d8aa124c40348362108109890cdc25a4f3cd8f7351c1007e15d6fdbb6ed7c5f
+bytes=278528
+same_image_as=CPH2841,OPD2513,PMA120
+codename=macan

--- a/ablrepo/PLZ110/abl.meta
+++ b/ablrepo/PLZ110/abl.meta
@@ -1,0 +1,6 @@
+product=PLZ110
+model=unknown
+soc=unknown
+abl_version=unknown
+sha256=ea95103a2c7e09004bd31a5fc01918610b9aef62be26540ab8ed3e1ab2905fa2
+bytes=1048576

--- a/ablrepo/PMA120/abl.meta
+++ b/ablrepo/PMA120/abl.meta
@@ -1,0 +1,7 @@
+product=PMA120
+model=unknown
+soc=unknown
+abl_version=unknown
+sha256=0d8aa124c40348362108109890cdc25a4f3cd8f7351c1007e15d6fdbb6ed7c5f
+bytes=278528
+same_image_as=CPH2841,OPD2513,PLR110

--- a/ablrepo/README.md
+++ b/ablrepo/README.md
@@ -10,9 +10,36 @@ ablrepo/
   <product>/
     abl.img       # raw ABL image with the GBL vulnerability
     abl.sha256    # sha256 of abl.img (sha256sum output format)
+    abl.meta      # identity + integrity metadata (key=value, LF)
 ```
 
 `<product>` is the value of `getprop ro.product.name` on the device, verbatim.
+
+## abl.meta
+
+`abl.meta` is a `key=value` file (LF line endings) with these keys, in order:
+
+| key | meaning |
+|-----|---------|
+| `product` | Directory name, verbatim; must equal `getprop ro.product.name` on the device. |
+| `model` | `getprop ro.product.model` of the device this image was taken from, or the literal `unknown`. |
+| `soc` | `getprop ro.board.platform` of the device this image was taken from, or the literal `unknown`. |
+| `abl_version` | Contents of `abl_version.txt` when present, else the literal `unknown`. |
+| `sha256` | sha256 of `abl.img` (must equal `abl.sha256`). |
+| `bytes` | Byte length of `abl.img`. |
+| `same_image_as` | Optional. Comma-separated list of other `<product>` directories whose `abl.img` is byte-identical to this one. |
+| `codename` | Optional, informational only. Device codename the repository evidences for this image (for example `macan`). Never gated on, because no `getprop` returns it verbatim on every build. |
+
+`model`, `soc` and `abl_version` are only as strong as the evidence in this
+repository; anything not corroborated here is recorded as `unknown`. A device
+codename is not a SoC: record it in `codename`, never in `soc`, or the identity
+check below will refuse the image on exactly the devices it was meant for.
+
+**A `same_image_as` binary has NOT been verified for each listed model.** It
+means one image was contributed under several product names, not that the image
+was confirmed to boot on all of them. The identity checks below exist because
+flashing an ABL that cannot run on the device is an unrecoverable-brick
+scenario.
 
 ## Lookup order
 
@@ -22,13 +49,28 @@ On first install, when the current ABL lacks the GBL vulnerability,
 1. **Local** — bundled inside the module ZIP at `$MODPATH/ablrepo/<product>/`
 2. **Cloud** — `https://raw.githubusercontent.com/superturtlee/gbl_root_canoe/main/ablrepo/<product>/`
 
-Both locations use the same layout. The image is verified against `abl.sha256`
-before use. After verification, the ABL is re-patched to confirm it actually
-has the GBL vulnerability; only then is it flashed to the `abl` partition.
+Both locations use the same layout. Before anything is flashed, the candidate
+image must pass all of these checks:
+
+1. `abl.meta` exists, its `product` equals `getprop ro.product.name`, and its
+   `sha256`/`bytes` match the candidate image.
+2. Any `model` other than `unknown` equals `getprop ro.product.model`; any
+   `soc` other than `unknown` equals `getprop ro.board.platform`.
+3. The candidate image is extracted and patched locally, and the GBL patch
+   must succeed — an image that does not take the patch is refused.
+
+Only then is the image flashed to the `abl` partition, and the patched loader
+and TrustZone map staged alongside it are re-derived from the *flashed* ABL,
+not from the one that was on flash before the downgrade.
 
 ## Adding a device
 
 1. Obtain an older ABL for the device that still has the GBL vulnerability.
 2. Name it `abl.img` and place it under `ablrepo/<product>/`.
 3. Generate the checksum: `sha256sum abl.img > abl.sha256`.
-4. Commit locally (bundled into the module) and push to `main` (cloud).
+4. Add `abl.meta` with the keys above; record `unknown` for anything you
+   cannot corroborate. Never claim a `model`/`soc` you did not read off a
+   device the image actually booted on.
+5. If the image is byte-identical to another product's, add `same_image_as`
+   on both sides — and understand it stays a warning sign, not an endorsement.
+6. Commit locally (bundled into the module) and push to `main` (cloud).

--- a/ablrepo/myron/abl.meta
+++ b/ablrepo/myron/abl.meta
@@ -1,0 +1,6 @@
+product=myron
+model=unknown
+soc=unknown
+abl_version=3.0.23.0
+sha256=7ad61d97208daa71898fad89839a0268f4d7b36f94e48585f67779330a82ecce
+bytes=335872

--- a/ablrepo/nezha/abl.meta
+++ b/ablrepo/nezha/abl.meta
@@ -1,0 +1,6 @@
+product=nezha
+model=unknown
+soc=unknown
+abl_version=unknown
+sha256=e673407e28e671aa49b86410e57ade7285e38145bda4dbbeeacdc39206bc79c4
+bytes=335872

--- a/ablrepo/nezha_global/abl.meta
+++ b/ablrepo/nezha_global/abl.meta
@@ -1,0 +1,6 @@
+product=nezha_global
+model=unknown
+soc=unknown
+abl_version=unknown
+sha256=8de296f69e7c3e38389f4dab544f547313dc54026262c14abdb0437f058549ff
+bytes=335672

--- a/ablrepo/pandora/abl.meta
+++ b/ablrepo/pandora/abl.meta
@@ -1,0 +1,6 @@
+product=pandora
+model=unknown
+soc=unknown
+abl_version=3.0.45.0
+sha256=607531d1858c8dd03e68c893bf9b03ba0a409490f348d8d34483f516df122f31
+bytes=335872

--- a/ablrepo/popsicle/abl.meta
+++ b/ablrepo/popsicle/abl.meta
@@ -1,0 +1,6 @@
+product=popsicle
+model=unknown
+soc=unknown
+abl_version=3.0.45.0
+sha256=34f4e6a1448f1f4f25d311c735a07f55dcfd86ee174000d17d35521054684a90
+bytes=335872

--- a/ablrepo/pudding/abl.meta
+++ b/ablrepo/pudding/abl.meta
@@ -1,0 +1,6 @@
+product=pudding
+model=unknown
+soc=unknown
+abl_version=3.0.44.0
+sha256=2566f645be236a6adc886bbf937914765bd4c24b1bf4d19241574f70295e7056
+bytes=335872

--- a/submodules/uefi/edk2/QcomModulePkg/Application/LinuxLoader/SuperFbLaunchPolicy.c
+++ b/submodules/uefi/edk2/QcomModulePkg/Application/LinuxLoader/SuperFbLaunchPolicy.c
@@ -178,6 +178,12 @@ SfbLoadTzMap (
     ZeroMem (Map, sizeof (*Map));
     return EFI_COMPROMISED_DATA;
   }
+  DEBUG ((EFI_D_INFO,
+          "SFB: MARK tzmap-digest abl=%02x%02x%02x%02x%02x%02x%02x%02x\n",
+          (UINT32)Map->AblDigest[0], (UINT32)Map->AblDigest[1],
+          (UINT32)Map->AblDigest[2], (UINT32)Map->AblDigest[3],
+          (UINT32)Map->AblDigest[4], (UINT32)Map->AblDigest[5],
+          (UINT32)Map->AblDigest[6], (UINT32)Map->AblDigest[7]));
   return EFI_SUCCESS;
 }
 

--- a/targets/magisk_module/module/customize.sh
+++ b/targets/magisk_module/module/customize.sh
@@ -79,6 +79,20 @@ if [ "$LANG" = "zh" ]; then
   T_ABLREPO_FAIL="ABL repo 查找失败，请手动刷写带 GBL 漏洞的旧版本 ABL 到 abl 分区后重试"
   T_ABLREPO_DOWNGRADE="正在降级 abl 分区..."
   T_ABLREPO_OK="abl 分区已降级"
+  T_ABL_META_FAIL="ABL repo 元数据校验失败"
+  T_ABL_CANDIDATE_FAIL="候选 ABL 未通过 GBL 补丁预检，已中止安装"
+  T_ABL_DOWNGRADE_GBL_FAIL="降级后的 ABL 仍无 GBL 漏洞，已中止安装"
+  T_ABL_NO_DOWNGRADE="当前 ABL 无 GBL 漏洞且未完成降级，已中止安装"
+  T_ABL_SIZE_FAIL="ABL 镜像大于目标分区，已中止安装"
+  T_ABL_SNAPSHOT_FAIL="ABL 原分区快照失败，已中止安装"
+  T_ABL_READBACK_FAIL="ABL 回读校验失败，已中止安装"
+  T_ABL_RESTORE_OK="ABL 回读失败，原 ABL 已成功恢复；安装已中止"
+  T_ABL_RESTORE_FAIL="ABL 回读失败，原 ABL 恢复失败；安装已中止"
+  T_TZMAP_BIND_FAIL="TrustZone map 与闪存中的 ABL 不匹配，已回滚安装"
+  T_INACTIVE_SLOT_UNRESOLVED="无法解析非活动槽位，跳过配对"
+  T_INACTIVE_SLOT_VULN_SKIP="非活动槽位已有 GBL 漏洞，跳过配对"
+  T_INACTIVE_SLOT_PAIRING="正在配对非活动槽位 ABL"
+  T_INACTIVE_SLOT_PAIR_WARN="警告：非活动槽位 ABL 配对失败，当前安装已保留"
   T_ABL_SETRW_FAIL="abl 分区设置可写失败"
   T_ABL_FLASH_FAIL="abl 分区降级刷写失败"
   T_SETRW_FAIL="efisp 分区设置可写失败"
@@ -135,6 +149,20 @@ else
   T_ABLREPO_OK="abl partition downgraded"
   T_ABL_SETRW_FAIL="Failed to set abl to read‑write"
   T_ABL_FLASH_FAIL="Failed to flash abl partition"
+  T_ABL_META_FAIL="ABL repo metadata verification failed"
+  T_ABL_CANDIDATE_FAIL="Candidate ABL failed the GBL patch preflight; aborting"
+  T_ABL_DOWNGRADE_GBL_FAIL="Downgraded ABL still lacks the GBL vulnerability; aborting"
+  T_ABL_NO_DOWNGRADE="Current ABL lacks GBL and no downgrade completed; aborting"
+  T_ABL_SIZE_FAIL="ABL image is larger than the target partition; aborting"
+  T_ABL_SNAPSHOT_FAIL="Failed to snapshot the outgoing ABL partition; aborting"
+  T_ABL_READBACK_FAIL="ABL readback verification failed; aborting"
+  T_ABL_RESTORE_OK="ABL readback failed; the original ABL was restored; aborting"
+  T_ABL_RESTORE_FAIL="ABL readback failed; restoring the original ABL failed; aborting"
+  T_TZMAP_BIND_FAIL="TrustZone map does not match the ABL on flash; install rolled back"
+  T_INACTIVE_SLOT_UNRESOLVED="Cannot resolve the inactive slot; skipping ABL pairing"
+  T_INACTIVE_SLOT_VULN_SKIP="Inactive-slot ABL already has the GBL vulnerability; skipping pairing"
+  T_INACTIVE_SLOT_PAIRING="Pairing the inactive-slot ABL"
+  T_INACTIVE_SLOT_PAIR_WARN="Warning: inactive-slot ABL pairing failed; committed install retained"
   T_SETRW_FAIL="Failed to set efisp to read‑write"
   T_FLASH_FAIL="Failed to flash efisp"
   T_PERSIST_NOT_MOUNTED="persist is not mounted at /mnt/vendor/persist"
@@ -237,6 +265,52 @@ download_url() {
   fi
 }
 
+# Read a required key from the ABL repository metadata file.
+abl_meta_value() {
+  sed -n "s/^$1=//p" "$2" | tail -n 1
+}
+
+verify_abl_metadata() {
+  metadata="$1"
+  image="$2"
+  product=$(getprop ro.product.name 2>/dev/null)
+  model=$(getprop ro.product.model 2>/dev/null)
+  soc=$(getprop ro.board.platform 2>/dev/null)
+  [ -f "$metadata" ] && [ -f "$image" ] || return 1
+  meta_product=$(abl_meta_value product "$metadata")
+  meta_model=$(abl_meta_value model "$metadata")
+  meta_soc=$(abl_meta_value soc "$metadata")
+  meta_abl_version=$(abl_meta_value abl_version "$metadata")
+  meta_sha256=$(abl_meta_value sha256 "$metadata")
+  meta_bytes=$(abl_meta_value bytes "$metadata")
+  [ "$meta_product" = "$product" ] || return 1
+  [ -n "$meta_model" ] && [ -n "$meta_soc" ] &&
+    [ -n "$meta_abl_version" ] || return 1
+  [ -n "$meta_sha256" ] && [ -n "$meta_bytes" ] || return 1
+  image_sha256=$(sha256sum "$image" | cut -d' ' -f1 | tr -d '[:space:]')
+  image_bytes=$(wc -c < "$image" | tr -d '[:space:]')
+  [ "$meta_sha256" = "$image_sha256" ] || return 1
+  [ "$meta_bytes" = "$image_bytes" ] || return 1
+  if [ "$meta_model" != "unknown" ] && [ "$meta_model" != "$model" ]; then
+    return 1
+  fi
+  if [ "$meta_soc" != "unknown" ] && [ "$meta_soc" != "$soc" ]; then
+    return 1
+  fi
+  return 0
+}
+
+# Download $1 into $2 using whichever fetcher is available.
+download_url() {
+  if command -v wget >/dev/null 2>&1; then
+    timeout 60 wget -O "$2" "$1" >/dev/null 2>&1
+  elif command -v curl >/dev/null 2>&1; then
+    timeout 60 curl -fL -o "$2" "$1" >/dev/null 2>&1
+  else
+    return 1
+  fi
+}
+
 # Fetch an older ABL with the GBL vulnerability. Looks up the local module
 # bundle first, then the cloud. On success, leaves the image at
 # $RUNTIME_DIR/repo_abl.img and returns 0; otherwise returns 1.
@@ -245,20 +319,30 @@ fetch_abl_from_repo() {
   [ -z "$product" ] && return 1
   local_dir="$MODPATH/ablrepo/$product"
   if [ -f "$local_dir/abl.img" ]; then
-    if [ -f "$local_dir/abl.sha256" ] && verify_sha256 "$local_dir/abl.img" "$local_dir/abl.sha256"; then
-      cp "$local_dir/abl.img" "$RUNTIME_DIR/repo_abl.img"
+    if [ ! -f "$local_dir/abl.sha256" ] ||
+       ! verify_sha256 "$local_dir/abl.img" "$local_dir/abl.sha256"; then
+      ui_print "$T_ABLREPO_LOCAL_BAD"
+    elif ! verify_abl_metadata "$local_dir/abl.meta" "$local_dir/abl.img"; then
+      ui_print "$T_ABL_META_FAIL"
+    elif ! cp "$local_dir/abl.img" "$RUNTIME_DIR/repo_abl.img"; then
+      ui_print "$T_ABLREPO_LOCAL_BAD"
+    else
       ui_print "$T_ABLREPO_LOCAL"
       return 0
     fi
-    ui_print "$T_ABLREPO_LOCAL_BAD"
   fi
   ui_print "$T_ABLREPO_CLOUD"
-  if download_url "$ABLREPO_URL/$product/abl.sha256" "$RUNTIME_DIR/repo_abl.sha256" && \
+  if download_url "$ABLREPO_URL/$product/abl.meta" "$RUNTIME_DIR/repo_abl.meta" &&
+     download_url "$ABLREPO_URL/$product/abl.sha256" "$RUNTIME_DIR/repo_abl.sha256" &&
      download_url "$ABLREPO_URL/$product/abl.img" "$RUNTIME_DIR/repo_abl.img"; then
-    if verify_sha256 "$RUNTIME_DIR/repo_abl.img" "$RUNTIME_DIR/repo_abl.sha256"; then
+    if ! verify_sha256 "$RUNTIME_DIR/repo_abl.img" "$RUNTIME_DIR/repo_abl.sha256"; then
+      ui_print "$T_ABLREPO_CLOUD_BAD"
+    elif ! verify_abl_metadata "$RUNTIME_DIR/repo_abl.meta" \
+         "$RUNTIME_DIR/repo_abl.img"; then
+      ui_print "$T_ABL_META_FAIL"
+    else
       return 0
     fi
-    ui_print "$T_ABLREPO_CLOUD_BAD"
   fi
   return 1
 }
@@ -267,15 +351,38 @@ ABL_TZMAP="$MODPATH/bin/abl_tzmap"
 abl_part="$BY_NAME_DIR/abl$current_slot_suffix"
 vbmeta_part="$BY_NAME_DIR/vbmeta$current_slot_suffix"
 
+preflight_candidate_abl() {
+  candidate="$1"
+  candidate_dir="$RUNTIME_DIR/candidate"
+  rm -rf "$candidate_dir"
+  mkdir -p "$candidate_dir" || return 1
+  if ! "$MODPATH/bin/extractfv" -o "$candidate_dir" -v "$candidate" \
+       > "$RUNTIME_DIR/candidate.extract.log" 2>&1 ||
+     ! "$MODPATH/bin/patch_abl" "$candidate_dir/LinuxLoader.efi" \
+       "$candidate_dir/patched.efi" > "$RUNTIME_DIR/candidate.patch.log" 2>&1 ||
+     [ ! -s "$candidate_dir/patched.efi" ]; then
+    return 1
+  fi
+  if grep -q "Warning: Failed to patch ABL GBL" \
+       "$RUNTIME_DIR/candidate.patch.log"; then
+    return 1
+  fi
+  return 0
+}
+
 preflight_current_pair() {
   rm -f "$RUNTIME_DIR/LinuxLoader.efi" "$RUNTIME_DIR/patched.efi" \
     "$RUNTIME_DIR/patch.log" "$RUNTIME_DIR/boot.efi.gm2p" \
     "$RUNTIME_DIR/boot.efi.tzmap"
+  CURRENT_PAIR_GBL_VULNERABLE=1
   if ! "$MODPATH/bin/extractfv" -o "$RUNTIME_DIR" -v "$abl_part" > "$RUNTIME_DIR/extract.log" 2>&1 ||
      ! "$MODPATH/bin/patch_abl" "$RUNTIME_DIR/LinuxLoader.efi" "$RUNTIME_DIR/patched.efi" > "$RUNTIME_DIR/patch.log" 2>&1 ||
      [ ! -s "$RUNTIME_DIR/patched.efi" ]; then
     ui_print "$T_PATCH_FAIL"
     return 1
+  fi
+  if grep -q "Warning: Failed to patch ABL GBL" "$RUNTIME_DIR/patch.log"; then
+    CURRENT_PAIR_GBL_VULNERABLE=0
   fi
   if [ ! -x "$MODE2_PROFILE" ] ||
      ! "$MODE2_PROFILE" derive --vbmeta "$vbmeta_part" --out "$RUNTIME_DIR/boot.efi.gm2p" > "$RUNTIME_DIR/profile.log" 2>&1 ||
@@ -297,6 +404,126 @@ preflight_current_pair() {
     rm -f "$RUNTIME_DIR/boot.efi.tzmap"
     return 1
   fi
+  return 0
+}
+
+abl_source_bytes() {
+  if [ -b "$1" ]; then
+    blockdev --getsize64 "$1" 2>/dev/null
+    return
+  fi
+  wc -c < "$1" 2>/dev/null | tr -d '[:space:]'
+}
+
+abl_hash() {
+  sha256sum "$1" 2>/dev/null | cut -d' ' -f1 | tr -d '[:space:]'
+}
+
+# Hash the first $2 bytes of $1 without materialising a copy: a byte-at-a-time
+# readback of a firmware partition costs minutes on device.
+abl_region_hash() {
+  region_dev="$1"
+  region_bytes="$2"
+  region_blocks=$(( (region_bytes + 4095) / 4096 ))
+  dd if="$region_dev" bs=4096 count="$region_blocks" 2>/dev/null |
+    head -c "$region_bytes" | sha256sum | cut -d' ' -f1 | tr -d '[:space:]'
+}
+
+restore_abl_snapshot() {
+  restore_target="$1"
+  restore_snapshot="$2"
+  restore_bytes="$3"
+  if ! dd if="$restore_snapshot" of="$restore_target" bs=4M conv=fsync \
+       >> "$RUNTIME_DIR/flash.log" 2>&1 ||
+     ! sync; then
+    return 1
+  fi
+  [ "$(abl_hash "$restore_snapshot")" = \
+    "$(abl_region_hash "$restore_target" "$restore_bytes")" ]
+}
+
+flash_abl_image() {
+  flash_source="$1"
+  flash_target="$2"
+  flash_snapshot="$3"
+  ABL_FLASH_STATUS=""
+  flash_target_bytes=$(blockdev --getsize64 "$flash_target" 2>/dev/null)
+  flash_source_bytes=$(abl_source_bytes "$flash_source")
+  case "$flash_target_bytes" in ''|*[!0-9]*) ABL_FLASH_STATUS=size; return 1 ;; esac
+  case "$flash_source_bytes" in ''|*[!0-9]*) ABL_FLASH_STATUS=size; return 1 ;; esac
+  if [ "$flash_source_bytes" -le 0 ] ||
+     [ "$flash_source_bytes" -gt "$flash_target_bytes" ]; then
+    ABL_FLASH_STATUS=size
+    return 1
+  fi
+  if ! blockdev --setrw "$flash_target" >> "$RUNTIME_DIR/flash.log" 2>&1; then
+    ABL_FLASH_STATUS=setrw
+    return 1
+  fi
+  rm -f "$flash_snapshot"
+  if ! dd if="$flash_target" of="$flash_snapshot" bs=4M conv=fsync \
+       >> "$RUNTIME_DIR/flash.log" 2>&1 ||
+     ! sync; then
+    ABL_FLASH_STATUS=snapshot
+    return 1
+  fi
+  if ! dd if="$flash_source" of="$flash_target" bs=4M conv=fsync \
+       >> "$RUNTIME_DIR/flash.log" 2>&1; then
+    ABL_FLASH_STATUS=flash
+    return 1
+  fi
+  if ! sync; then
+    ABL_FLASH_STATUS=sync
+    return 1
+  fi
+  if [ "$(abl_hash "$flash_source")" != \
+       "$(abl_region_hash "$flash_target" "$flash_source_bytes")" ]; then
+    if restore_abl_snapshot "$flash_target" "$flash_snapshot" \
+         "$flash_target_bytes"; then
+      ABL_FLASH_STATUS=readback_restore_ok
+    else
+      ABL_FLASH_STATUS=readback_restore_fail
+    fi
+    return 1
+  fi
+  return 0
+}
+
+abl_is_gbl_vulnerable() {
+  inspect_abl="$1"
+  inspect_dir="$2"
+  rm -rf "$inspect_dir"
+  mkdir -p "$inspect_dir" || return 1
+  if ! "$MODPATH/bin/extractfv" -o "$inspect_dir" -v "$inspect_abl" \
+       > "$inspect_dir/extract.log" 2>&1 ||
+     ! "$MODPATH/bin/patch_abl" "$inspect_dir/LinuxLoader.efi" \
+       "$inspect_dir/patched.efi" > "$inspect_dir/patch.log" 2>&1; then
+    return 1
+  fi
+  if ! grep -q "Warning: Failed to patch ABL GBL" "$inspect_dir/patch.log"; then
+    return 0
+  fi
+  return 1
+}
+
+pair_inactive_abl() {
+  inactive_slot_suffix=
+  case "$current_slot_suffix" in
+    _a) inactive_slot_suffix=_b ;;
+    _b) inactive_slot_suffix=_a ;;
+    *) ui_print "$T_INACTIVE_SLOT_UNRESOLVED"; return 0 ;;
+  esac
+  inactive_abl_part="$BY_NAME_DIR/abl$inactive_slot_suffix"
+  if abl_is_gbl_vulnerable "$inactive_abl_part" "$RUNTIME_DIR/inactive-abl"; then
+    ui_print "$T_INACTIVE_SLOT_VULN_SKIP"
+    return 0
+  fi
+  ui_print "$T_INACTIVE_SLOT_PAIRING"
+  if flash_abl_image "$abl_part" "$inactive_abl_part" \
+       "$RUNTIME_DIR/inactive_abl_pre.img"; then
+    return 0
+  fi
+  ui_print "$T_INACTIVE_SLOT_PAIR_WARN"
   return 0
 }
 
@@ -757,7 +984,9 @@ while true; do
     if ! pair_recover "$EFISP_DIR"; then
       abort "pair transaction recovery failed before optional patch"
     fi
-    if grep -q "Warning: Failed to patch ABL GBL" "$RUNTIME_DIR/patch.log"; then
+    initial_pair_gbl_vulnerable="$CURRENT_PAIR_GBL_VULNERABLE"
+    abl_downgrade_done=0
+    if [ "$initial_pair_gbl_vulnerable" = "0" ]; then
       ui_print "$T_NO_GBL"
       ui_print "$T_ABLREPO_CONFIRM"
       ui_print "$T_ABLREPO_CONFIRM_YES"
@@ -779,24 +1008,61 @@ while true; do
         ui_print "$T_ABLREPO_FAIL"
         abort "abl repo lookup failed"
       fi
+      if ! preflight_candidate_abl "$RUNTIME_DIR/repo_abl.img"; then
+        ui_print "$T_ABL_CANDIDATE_FAIL"
+        abort "candidate ABL preflight failed"
+      fi
       ui_print "$T_ABLREPO_DOWNGRADE"
       if ! pair_recover "$EFISP_DIR"; then
         abort "pair transaction recovery failed before ABL downgrade"
       fi
-
-      if ! blockdev --setrw "$abl_part" >> "$RUNTIME_DIR/flash.log" 2>&1; then
-        ui_print "$T_ABL_SETRW_FAIL"
-        abort "setrw abl failed"
+      if ! flash_abl_image "$RUNTIME_DIR/repo_abl.img" "$abl_part" \
+           "$RUNTIME_DIR/abl_pre.img"; then
+        case "$ABL_FLASH_STATUS" in
+          setrw)
+            ui_print "$T_ABL_SETRW_FAIL"
+            abort "setrw abl failed"
+            ;;
+          size)
+            ui_print "$T_ABL_SIZE_FAIL"
+            abort "abl image does not fit"
+            ;;
+          snapshot)
+            ui_print "$T_ABL_SNAPSHOT_FAIL"
+            abort "abl snapshot failed"
+            ;;
+          readback_restore_ok)
+            ui_print "$T_ABL_RESTORE_OK"
+            abort "abl readback mismatch; restore succeeded"
+            ;;
+          readback_restore_fail)
+            ui_print "$T_ABL_RESTORE_FAIL"
+            abort "abl readback mismatch; restore failed"
+            ;;
+          sync)
+            ui_print "$T_ABL_FLASH_FAIL"
+            abort "sync downgraded abl failed"
+            ;;
+          *)
+            ui_print "$T_ABL_FLASH_FAIL"
+            abort "downgrade abl failed"
+            ;;
+        esac
       fi
-      if ! dd if="$RUNTIME_DIR/repo_abl.img" of="$abl_part" bs=4M conv=fsync >> "$RUNTIME_DIR/flash.log" 2>&1; then
-        ui_print "$T_ABL_FLASH_FAIL"
-        abort "downgrade abl failed"
+      if ! preflight_current_pair; then
+        abort "ABL/vbmeta/profile preflight after downgrade failed"
       fi
-      if ! sync; then
-        ui_print "$T_ABL_FLASH_FAIL"
-        abort "sync downgraded abl failed"
+      if [ "$CURRENT_PAIR_GBL_VULNERABLE" != "1" ]; then
+        ui_print "$T_ABL_DOWNGRADE_GBL_FAIL"
+        abort "downgraded ABL is not GBL-vulnerable"
       fi
+      abl_downgrade_done=1
       ui_print "$T_ABLREPO_OK"
+    fi
+    if [ "$initial_pair_gbl_vulnerable" = "0" ] &&
+       [ "$abl_downgrade_done" != "1" ]; then
+      ui_print "$T_ABL_NO_DOWNGRADE"
+      abort "non-vulnerable ABL was not downgraded"
     fi
 
     ui_print "$T_PLACE_BOOT"
@@ -818,6 +1084,15 @@ while true; do
       fi
       ui_print "$T_EFISP_WRITE_FAIL"
       abort "efisp pair write failed"
+    fi
+    if ! "$ABL_TZMAP" verify --sidecar "$EFISP_DIR/boot.efi.tzmap" \
+         --abl "$RUNTIME_DIR/LinuxLoader.efi" --allow-zero-digest \
+         >> "$RUNTIME_DIR/tzmap.log" 2>&1; then
+      if ! pair_restore "$EFISP_DIR"; then
+        ui_print "$T_EFISP_WRITE_FAIL"
+      fi
+      ui_print "$T_TZMAP_BIND_FAIL"
+      abort "ABL TrustZone map binding failed"
     fi
 
     ui_print "$T_FLASH_BDS"
@@ -877,6 +1152,7 @@ while true; do
         abort "efisp pair commit failed"
         ;;
     esac
+    pair_inactive_abl
     ui_print "$T_DONE_YES"
     rm -rf "$RUNTIME_DIR"
     break

--- a/targets/magisk_module/tests/test_flows.sh
+++ b/targets/magisk_module/tests/test_flows.sh
@@ -11,7 +11,7 @@ BY_NAME="$TMP/by-name"
 PERSIST="$TMP/persist"
 EFISP="$PERSIST/efisp"
 MODE_MISMATCH_USED="$TMP/mode-mismatch.used"
-PAIR_TARGET=""
+ABL_READBACK_USED="$TMP/abl-readback.used"
 PAIR_SYNC_FAILED="$TMP/pair-sync-failed"
 RAW_SYNC_FAILED="$TMP/raw-sync-failed"
 RAW_SYNC_REACHED="$TMP/raw-sync-reached"
@@ -33,7 +33,12 @@ assert_contains() { case "$1" in *"$2"*) ;; *) fail "$3" ;; esac; }
 # ordering and transaction logic; these commands only model Android services.
 cat > "$BIN/getprop" <<'EOF'
 #!/bin/sh
-[ "$1" = ro.boot.slot_suffix ] && { echo _a; exit 0; }
+case "$1" in
+  ro.boot.slot_suffix) echo _a ;;
+  ro.product.name) echo test-device ;;
+  ro.product.model) echo Test Model ;;
+  ro.board.platform) echo sm8850 ;;
+esac
 exit 0
 EOF
 cat > "$BIN/blockdev" <<'EOF'
@@ -53,12 +58,32 @@ for arg in "$@"; do
   case "$arg" in if=*) in=${arg#*=} ;; of=*) out=${arg#*=} ;; esac
 done
 printf 'dd %s -> %s\n' "$in" "$out" >> "$FLOW_LOG"
-[ -n "$in" ] && [ -n "$out" ] && [ -f "$in" ] && /bin/cp "$in" "$out"
-EOF
-cat > "$BIN/grep" <<'EOF'
-#!/bin/sh
-case "$*" in *persist*) exit 0 ;; esac
-exec /usr/bin/grep "$@"
+if [ -z "$out" ]; then
+  # Verification read: real dd streams the device to stdout. Corrupt that
+  # stream once when the case under test asks for a readback mismatch.
+  case "$in" in
+    */by-name/abl_*)
+      if [ "${FAIL_ABL_READBACK:-0}" = 1 ] &&
+         [ ! -e "$ABL_READBACK_USED" ]; then
+        : > "$ABL_READBACK_USED"
+        printf 'readback-corrupt\n'
+        exit 0
+      fi
+      ;;
+  esac
+  [ -n "$in" ] && [ -f "$in" ] && /bin/cat "$in"
+  exit 0
+fi
+if [ -n "$in" ] && [ -f "$in" ]; then
+  /bin/cp "$in" "$out"
+fi
+case "$out" in
+  */by-name/abl_b)
+    if [ "${FAIL_INACTIVE_PAIR:-0}" = 1 ]; then
+      printf 'inactive-pair-corrupt\n' > "$out"
+    fi
+    ;;
+esac
 EOF
 cat > "$BIN/extractfv" <<'EOF'
 #!/bin/sh
@@ -71,7 +96,11 @@ while [ "$#" -gt 0 ]; do
     *) shift ;;
   esac
 done
-printf 'linux-loader:%s\n' "$abl" > "$out/LinuxLoader.efi"
+{
+  printf 'linux-loader:%s:' "$abl"
+  cat "$abl"
+  printf '\n'
+} > "$out/LinuxLoader.efi"
 printf 'extractfv %s\n' "$abl" >> "$FLOW_LOG"
 EOF
 cat > "$BIN/patch_abl" <<'EOF'
@@ -80,9 +109,17 @@ cat "$1" > "$2"
 # GBL_VULNERABLE=1 models an ABL that still carries the GBL bug (patch
 # succeeds); 0 models a fixed ABL, which is what drives the downgrade path.
 if [ "${GBL_VULNERABLE:-1}" != 1 ]; then
-  printf 'Warning: Failed to patch ABL GBL\n'
+  if ! /usr/bin/grep -q candidate-good "$1" ||
+     [ "${FAIL_POST_DOWNGRADE_GBL:-0}" = 1 ]; then
+    printf 'Warning: Failed to patch ABL GBL\n'
+  fi
 fi
 printf 'patch_abl %s -> %s\n' "$1" "$2" >> "$FLOW_LOG"
+EOF
+cat > "$BIN/grep" <<'EOF'
+#!/bin/sh
+case "$*" in *persist*) exit 0 ;; esac
+exec /usr/bin/grep "$@"
 EOF
 cat > "$BIN/abl_tzmap" <<'EOF'
 #!/bin/sh
@@ -110,6 +147,22 @@ case "$cmd" in
     echo "tzmap validate $input" >> "$FLOW_LOG"
     [ "${FAIL_TZMAP_VALIDATE:-0}" = 1 ] && exit 1
     [ -s "$input" ]
+    ;;
+  verify)
+    sidecar= abl=
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --sidecar) sidecar=$2; shift 2 ;;
+        --abl) abl=$2; shift 2 ;;
+        --allow-zero-digest) shift ;;
+        *) shift ;;
+      esac
+    done
+    echo "tzmap verify $sidecar $abl" >> "$FLOW_LOG"
+    [ "${FAIL_TZMAP_VERIFY:-0}" = 0 ] || exit 1
+    [ -s "$sidecar" ] && [ -s "$abl" ] || exit 1
+    case "$(cat "$sidecar")" in *"$(cat "$abl")"*) exit 0 ;; esac
+    exit 1
     ;;
   *) exit 1 ;;
 esac
@@ -267,6 +320,7 @@ run() {
     PAIR_SYNC_FAILED="$PAIR_SYNC_FAILED" RAW_SYNC_FAILED="$RAW_SYNC_FAILED" \
     RAW_SYNC_REACHED="$RAW_SYNC_REACHED" STATIC_SYNC_FAILED="$STATIC_SYNC_FAILED" \
     DEBUG_SYNC_FAILED="$DEBUG_SYNC_FAILED" ABL_SYNC_FAILED="$ABL_SYNC_FAILED" \
+    KEY_STATE="$TMP/key.state" ABL_READBACK_USED="$TMP/abl-readback.used" \
     FAIL_DERIVE="${FAIL_DERIVE:-0}" FAIL_MODE_READ="${FAIL_MODE_READ:-0}" \
     FAIL_MODE_WRITE="${FAIL_MODE_WRITE:-0}" FAIL_MODE_WRITE_MISMATCH="${FAIL_MODE_WRITE_MISMATCH:-0}" \
     FAIL_COMMIT_SYNC="${FAIL_COMMIT_SYNC:-0}" FAIL_BDS_SYNC="${FAIL_BDS_SYNC:-0}" \
@@ -297,12 +351,15 @@ run_customize() {
     PAIR_SYNC_FAILED="$PAIR_SYNC_FAILED" RAW_SYNC_FAILED="$RAW_SYNC_FAILED" \
     RAW_SYNC_REACHED="$RAW_SYNC_REACHED" STATIC_SYNC_FAILED="$STATIC_SYNC_FAILED" \
     DEBUG_SYNC_FAILED="$DEBUG_SYNC_FAILED" ABL_SYNC_FAILED="$ABL_SYNC_FAILED" \
-    KEY_STATE="$TMP/key.state" FAIL_DERIVE="${FAIL_DERIVE:-0}" \
-    FAIL_MODE_READ="${FAIL_MODE_READ:-0}" FAIL_MODE_WRITE="${FAIL_MODE_WRITE:-0}" \
-    FAIL_MODE_WRITE_MISMATCH="${FAIL_MODE_WRITE_MISMATCH:-0}" \
+    KEY_STATE="$TMP/key.state" ABL_READBACK_USED="$TMP/abl-readback.used" \
+    FAIL_DERIVE="${FAIL_DERIVE:-0}" FAIL_MODE_READ="${FAIL_MODE_READ:-0}" \
+    FAIL_MODE_WRITE="${FAIL_MODE_WRITE:-0}" FAIL_MODE_WRITE_MISMATCH="${FAIL_MODE_WRITE_MISMATCH:-0}" \
     FAIL_COMMIT_SYNC="${FAIL_COMMIT_SYNC:-0}" FAIL_BDS_SYNC="${FAIL_BDS_SYNC:-0}" \
     FAIL_STATIC_SYNC="${FAIL_STATIC_SYNC:-0}" FAIL_DEBUG_SYNC="${FAIL_DEBUG_SYNC:-0}" \
-    FAIL_ABL_SYNC="${FAIL_ABL_SYNC:-0}" FORCE_NO_GBL="${FORCE_NO_GBL:-0}" \
+    FAIL_ABL_SYNC="${FAIL_ABL_SYNC:-0}" FAIL_TZMAP_VERIFY="${FAIL_TZMAP_VERIFY:-0}" \
+    FAIL_INACTIVE_PAIR="${FAIL_INACTIVE_PAIR:-0}" FAIL_ABL_READBACK="${FAIL_ABL_READBACK:-0}" \
+    FAIL_POST_DOWNGRADE_GBL="${FAIL_POST_DOWNGRADE_GBL:-0}" \
+    FORCE_NO_GBL="${FORCE_NO_GBL:-0}" \
     GBL_VULNERABLE="${GBL_VULNERABLE:-1}" \
     FINAL_INSTALL_DOWN="${FINAL_INSTALL_DOWN:-0}" REPO_CONFIRM_UP="${REPO_CONFIRM_UP:-0}" \
     FAIL_PAIR_CP="${FAIL_PAIR_CP:-0}" FAIL_PAIR_MV="${FAIL_PAIR_MV:-0}" \
@@ -384,8 +441,125 @@ assert_file "$EFISP/boot.efi.gm2p"
 assert_file "$EFISP/boot.efi.tzmap"
 assert_contains "$(cat "$MODE_STATE")" 'MODE=1' "fresh install did not materialize default Mode 1"
 pass "fresh install preflight ordering and paired install"
+
+make_repo_image() {
+  rm -rf "$MOD/ablrepo"
+  mkdir -p "$MOD/ablrepo/test-device"
+  printf '%s\n' "$1" > "$MOD/ablrepo/test-device/abl.img"
+  sha256sum "$MOD/ablrepo/test-device/abl.img" \
+    > "$MOD/ablrepo/test-device/abl.sha256"
+  repo_sha256=$(sha256sum "$MOD/ablrepo/test-device/abl.img" |
+    cut -d' ' -f1)
+  repo_bytes=$(wc -c < "$MOD/ablrepo/test-device/abl.img" |
+    tr -d '[:space:]')
+  cat > "$MOD/ablrepo/test-device/abl.meta" <<EOF
+product=test-device
+model=Test Model
+soc=sm8850
+abl_version=fixture
+sha256=$repo_sha256
+bytes=$repo_bytes
+EOF
+}
+
+# A vulnerable inactive slot is left alone; the fresh install completes
+# without a cross-slot ABL write.
+! /usr/bin/grep -q "dd .*abl_a -> .*abl_b" "$LOG" ||
+  fail "fresh install rewrote an already-vulnerable inactive ABL"
+pass "fresh install skips vulnerable inactive-slot pairing"
+
+# Sidecar binding failure rolls back the staged pair before any BDS write.
+sidecar_live_before=$(cat "$EFISP/boot.efi")
+sidecar_profile_before=$(cat "$EFISP/boot.efi.gm2p")
+sidecar_tzmap_before=$(cat "$EFISP/boot.efi.tzmap")
+: > "$LOG"
+printf '0\n' > "$TMP/key.state"
+sidecar_rc=0
+FAIL_TZMAP_VERIFY=1 run_customize >/dev/null 2>&1 || sidecar_rc=$?
+[ "$sidecar_rc" -ne 0 ] || fail "sidecar/ABL mismatch was accepted"
+assert_eq "$(cat "$EFISP/boot.efi")" "$sidecar_live_before" \
+  "sidecar mismatch changed live EFI"
+assert_eq "$(cat "$EFISP/boot.efi.gm2p")" "$sidecar_profile_before" \
+  "sidecar mismatch changed profile"
+assert_eq "$(cat "$EFISP/boot.efi.tzmap")" "$sidecar_tzmap_before" \
+  "sidecar mismatch changed tzmap"
+! /usr/bin/grep -q '^dd .*by-name/efisp' "$LOG" ||
+  fail "sidecar mismatch wrote BDS"
+pass "sidecar/ABL mismatch rolls back staged pair"
+
+# A candidate image with no successful GBL patch is rejected before setrw or
+# any ABL write.
+make_repo_image candidate-fixed
+: > "$LOG"
+printf '0\n' > "$TMP/key.state"
+candidate_rc=0
+GBL_VULNERABLE=0 REPO_CONFIRM_UP=1 run_customize >/dev/null 2>&1 ||
+  candidate_rc=$?
+[ "$candidate_rc" -ne 0 ] || fail "unpatchable candidate ABL was accepted"
+! /usr/bin/grep -q '^setrw .*abl_a\|^dd .*abl_a' "$LOG" ||
+  fail "candidate preflight wrote the active ABL"
+pass "candidate ABL patch preflight rejects fixed image"
+
+# A candidate that patches cleanly but leaves a warning after downgrade must
+# not stage a pair.
+make_repo_image candidate-good
+: > "$LOG"
+printf '0\n' > "$TMP/key.state"
+surviving_warning_rc=0
+GBL_VULNERABLE=0 REPO_CONFIRM_UP=1 FAIL_POST_DOWNGRADE_GBL=1 \
+  run_customize >/dev/null 2>&1 || surviving_warning_rc=$?
+[ "$surviving_warning_rc" -ne 0 ] ||
+  fail "post-downgrade GBL warning was accepted"
+! /usr/bin/grep -q '^mv .*canoe.new\|^cp .*canoe.new' "$LOG" ||
+  fail "pair was staged after post-downgrade GBL warning"
+pass "post-downgrade GBL warning blocks staging"
+
+# A readback mismatch restores the full outgoing ABL and reports that the
+# restore succeeded.
+printf 'abl-a-original\n' > "$BY_NAME/abl_a"
+: > "$LOG"
+printf '0\n' > "$TMP/key.state"
+rm -f "$ABL_READBACK_USED"
+readback_rc=0
+GBL_VULNERABLE=0 REPO_CONFIRM_UP=1 FAIL_ABL_READBACK=1 \
+  run_customize >/tmp/canoe-customize-readback.$$.out 2>&1 || readback_rc=$?
+[ "$readback_rc" -ne 0 ] || fail "ABL readback mismatch was accepted"
+assert_eq "$(cat "$BY_NAME/abl_a")" 'abl-a-original' \
+  "ABL readback mismatch did not restore outgoing ABL"
+assert_contains "$(cat /tmp/canoe-customize-readback.$$.out)" \
+  'restore succeeded' "ABL readback failure omitted restore status"
+rm -f /tmp/canoe-customize-readback.$$.out
+pass "ABL readback mismatch restores and reports outgoing ABL"
+
+# A non-vulnerable inactive slot is paired only after the active install has
+# committed.
+printf 'abl-a-original\n' > "$BY_NAME/abl_a"
+printf 'abl-b-fixed\n' > "$BY_NAME/abl_b"
+: > "$LOG"
+printf '0\n' > "$TMP/key.state"
+GBL_VULNERABLE=0 REPO_CONFIRM_UP=1 run_customize >/dev/null
+assert_contains "$(cat "$LOG")" "dd $BY_NAME/abl_a -> $BY_NAME/abl_b" \
+  "inactive ABL pairing was not attempted"
+assert_eq "$(cat "$BY_NAME/abl_b")" 'candidate-good' \
+  "inactive ABL was not copied from active slot"
+pass "inactive-slot ABL pairing copies known-good active image"
+
+# A failed inactive-slot copy is warning-only after pair_commit: the
+# committed efisp pair remains installed.
+printf 'abl-b-fixed-again\n' > "$BY_NAME/abl_b"
+make_repo_image candidate-good
+pair_live_expected=$(cat "$EFISP/boot.efi")
+printf '0\n' > "$TMP/key.state"
+FAIL_INACTIVE_PAIR=1 run_customize >/dev/null
+assert_eq "$(cat "$EFISP/boot.efi")" "$pair_live_expected" \
+  "inactive pairing failure rolled back committed install"
+assert_contains "$(cat "$LOG")" "dd $BY_NAME/abl_a -> $BY_NAME/abl_b" \
+  "inactive pairing failure did not attempt copy"
+pass "failed inactive-slot pairing retains committed install"
+
 # A selected optional patch must not run before the user can decline a required
 # ABL downgrade. Without the ordering fix, patch_tools appears before abort.
+printf 'abl-a\n' > "$BY_NAME/abl_a"
 : > "$LOG"
 printf '0\n' > "$TMP/key.state"
 optional_live_before=$(cat "$EFISP/boot.efi")
@@ -401,6 +575,8 @@ assert_eq "$(cat "$EFISP/boot.efi")" "$optional_live_before" \
   fail "declined ABL downgrade performed a live write"
 pass "declined ABL downgrade leaves optional patch untouched"
 
+printf 'abl-a\n' > "$BY_NAME/abl_a"
+printf 'abl-b\n' > "$BY_NAME/abl_b"
 # Reset the pair so OTA rotation assertions have a stable independent fixture.
 printf 'old-live\n' > "$EFISP/boot.efi"
 printf 'old-live-profile\n' > "$EFISP/boot.efi.gm2p"

--- a/tools/abl-tzmap/src/lib.rs
+++ b/tools/abl-tzmap/src/lib.rs
@@ -165,6 +165,50 @@ pub enum ValidateFileError {
     Invalid(#[from] ManifestError),
 }
 
+#[derive(Debug, Error)]
+pub enum VerifyFileError {
+    #[error("unreadable sidecar input: {0}")]
+    ReadSidecar(#[source] io::Error),
+    #[error("sidecar parse failed: {0}")]
+    Parse(#[from] ManifestError),
+    #[error("unreadable ABL input: {0}")]
+    ReadAbl(#[source] io::Error),
+    #[error("sidecar contains an all-zero ABL digest; pass --allow-zero-digest to permit it")]
+    ZeroDigest,
+    #[error("sidecar digest mismatch: sidecar={sidecar}, actual={actual}")]
+    DigestMismatch { sidecar: String, actual: String },
+}
+
+pub fn verify_file(
+    sidecar_path: &Path,
+    abl_path: &Path,
+    allow_zero_digest: bool,
+) -> Result<(), VerifyFileError> {
+    let map = validate_file(sidecar_path).map_err(|error| match error {
+        ValidateFileError::Read(source) => VerifyFileError::ReadSidecar(source),
+        ValidateFileError::Invalid(source) => VerifyFileError::Parse(source),
+    })?;
+    let zero_digest = map.abl_digest == [0; 32];
+    if zero_digest && !allow_zero_digest {
+        return Err(VerifyFileError::ZeroDigest);
+    }
+    let mut file = File::open(abl_path).map_err(VerifyFileError::ReadAbl)?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes).map_err(VerifyFileError::ReadAbl)?;
+    let actual = scan::digest(&bytes);
+    if zero_digest {
+        return Ok(());
+    }
+    if map.abl_digest != actual {
+        return Err(VerifyFileError::DigestMismatch {
+            sidecar: hex_digest(&map.abl_digest),
+            actual: hex_digest(&actual),
+        });
+    }
+    Ok(())
+}
+
+
 pub fn validate_file(input_path: &Path) -> Result<TzMap, ValidateFileError> {
     let file = File::open(input_path).map_err(ValidateFileError::Read)?;
     let mut bytes = Vec::with_capacity(TZMAP_SIZE + 1);

--- a/tools/abl-tzmap/src/lib.rs
+++ b/tools/abl-tzmap/src/lib.rs
@@ -177,6 +177,11 @@ pub enum VerifyFileError {
     ZeroDigest,
     #[error("sidecar digest mismatch: sidecar={sidecar}, actual={actual}")]
     DigestMismatch { sidecar: String, actual: String },
+    #[error(
+        "ABL input is not a regular file: {0}. The digest covers the extracted, \
+         unpatched loader, never the abl partition; extract it first."
+    )]
+    AblNotRegularFile(String),
 }
 
 pub fn verify_file(
@@ -191,6 +196,12 @@ pub fn verify_file(
     let zero_digest = map.abl_digest == [0; 32];
     if zero_digest && !allow_zero_digest {
         return Err(VerifyFileError::ZeroDigest);
+    }
+    let abl_meta = fs::metadata(abl_path).map_err(VerifyFileError::ReadAbl)?;
+    if !abl_meta.is_file() {
+        return Err(VerifyFileError::AblNotRegularFile(
+            abl_path.display().to_string(),
+        ));
     }
     let mut file = File::open(abl_path).map_err(VerifyFileError::ReadAbl)?;
     let mut bytes = Vec::new();

--- a/tools/abl-tzmap/src/main.rs
+++ b/tools/abl-tzmap/src/main.rs
@@ -1,7 +1,10 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use abl_tzmap::{DeriveFileError, ScanFileError, ValidateFileError, derive_to_file, enumeration_text, scan_file, validate_file};
+use abl_tzmap::{
+    DeriveFileError, ScanFileError, ValidateFileError, VerifyFileError, derive_to_file,
+    enumeration_text, scan_file, validate_file, verify_file,
+};
 use clap::{Parser, Subcommand};
 use thiserror::Error;
 
@@ -29,6 +32,15 @@ enum Command {
     },
     /// Strictly validate one 256-byte .tzmap sidecar.
     Validate { file: PathBuf },
+    /// Verify a sidecar's ABL digest against an ABL file.
+    Verify {
+        #[arg(long)]
+        sidecar: PathBuf,
+        #[arg(long)]
+        abl: PathBuf,
+        #[arg(long)]
+        allow_zero_digest: bool,
+    },
 }
 
 #[derive(Debug, Error)]
@@ -39,6 +51,8 @@ enum CliError {
     Derive(#[from] DeriveFileError),
     #[error("validate: {0}")]
     Validate(#[from] ValidateFileError),
+    #[error("verify: {0}")]
+    Verify(#[from] VerifyFileError),
 }
 
 fn run(cli: Cli) -> Result<(), CliError> {
@@ -58,6 +72,10 @@ fn run(cli: Cli) -> Result<(), CliError> {
             derive_to_file(&abl, &out, allow_incomplete).map_err(CliError::from)
         }
         Command::Validate { file } => { validate_file(&file)?; Ok(()) }
+        Command::Verify { sidecar, abl, allow_zero_digest } => {
+            verify_file(&sidecar, &abl, allow_zero_digest)?;
+            Ok(())
+        }
     }
 }
 

--- a/tools/abl-tzmap/src/scan.rs
+++ b/tools/abl-tzmap/src/scan.rs
@@ -197,7 +197,7 @@ fn cap_commands(commands: &mut Vec<CommandRecord>) -> Result<(), ScanError> {
     Ok(())
 }
 
-fn digest(data: &[u8]) -> [u8; 32] {
+pub(crate) fn digest(data: &[u8]) -> [u8; 32] {
     let digest = Sha256::digest(data);
     let mut output = [0u8; 32];
     output.copy_from_slice(&digest);

--- a/tools/abl-tzmap/tests/verify.rs
+++ b/tools/abl-tzmap/tests/verify.rs
@@ -1,0 +1,71 @@
+use std::fs;
+
+use abl_tzmap::{TzMap, VerifyFileError, TZMAP_SIZE, verify_file};
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+fn abl_digest(bytes: &[u8]) -> [u8; 32] {
+    let digest = Sha256::digest(bytes);
+    let mut output = [0u8; 32];
+    output.copy_from_slice(&digest);
+    output
+}
+
+fn fixture(digest: [u8; 32]) -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let directory = tempfile::tempdir().expect("temp dir");
+    let abl = directory.path().join("boot.efi");
+    let sidecar = directory.path().join("boot.efi.tzmap");
+    fs::write(&abl, b"fixture ABL").expect("write ABL");
+    fs::write(&sidecar, TzMap::new(0, digest, Vec::new()).expect("valid map").to_bytes())
+        .expect("write sidecar");
+    (directory, sidecar, abl)
+}
+
+#[test]
+fn matching_digest_passes() {
+    let abl = b"fixture ABL";
+    let (_directory, sidecar, abl_path) = fixture(abl_digest(abl));
+
+    verify_file(&sidecar, &abl_path, false).expect("matching digest verifies");
+}
+
+#[test]
+fn mismatching_digest_fails_with_both_digests() {
+    let (_directory, sidecar, abl_path) = fixture([0x11; 32]);
+
+    let error = verify_file(&sidecar, &abl_path, false).expect_err("mismatch must fail");
+    match error {
+        VerifyFileError::DigestMismatch { sidecar, actual } => {
+            assert_eq!(sidecar, "1111111111111111111111111111111111111111111111111111111111111111");
+            assert_eq!(actual, "afc6d7bad7a82ded4abb47c98199956a0ce95e678e0eb03cc445725ba163bd49");
+        }
+        other => panic!("expected digest mismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn truncated_and_oversized_sidecars_fail_to_parse() {
+    let (_directory, sidecar, abl_path) = fixture(abl_digest(b"fixture ABL"));
+    fs::write(&sidecar, vec![0u8; TZMAP_SIZE - 1]).expect("write truncated sidecar");
+    assert!(matches!(
+        verify_file(&sidecar, &abl_path, false),
+        Err(VerifyFileError::Parse(_))
+    ));
+
+    fs::write(&sidecar, vec![0u8; TZMAP_SIZE + 1]).expect("write oversized sidecar");
+    assert!(matches!(
+        verify_file(&sidecar, &abl_path, false),
+        Err(VerifyFileError::Parse(_))
+    ));
+}
+
+#[test]
+fn all_zero_digest_requires_explicit_flag() {
+    let (_directory, sidecar, abl_path) = fixture([0; 32]);
+
+    assert!(matches!(
+        verify_file(&sidecar, &abl_path, false),
+        Err(VerifyFileError::ZeroDigest)
+    ));
+    verify_file(&sidecar, &abl_path, true).expect("explicit zero-digest override verifies");
+}

--- a/tools/abl-tzmap/tests/verify.rs
+++ b/tools/abl-tzmap/tests/verify.rs
@@ -44,6 +44,24 @@ fn mismatching_digest_fails_with_both_digests() {
 }
 
 #[test]
+fn non_regular_abl_input_is_refused() {
+    let abl = b"fixture ABL";
+    let (directory, sidecar, _abl_path) = fixture(abl_digest(abl));
+    // A partition path is the mistake this refusal exists for; a directory is
+    // the portable stand-in for "not a regular file".
+    let not_a_file = directory.path().join("as-a-directory");
+    fs::create_dir(&not_a_file).expect("create directory");
+
+    let error = verify_file(&sidecar, &not_a_file, false).expect_err("must refuse");
+    match error {
+        VerifyFileError::AblNotRegularFile(path) => {
+            assert!(path.ends_with("as-a-directory"), "unexpected path: {path}");
+        }
+        other => panic!("expected non-regular-file refusal, got {other:?}"),
+    }
+}
+
+#[test]
 fn truncated_and_oversized_sidecars_fail_to_parse() {
     let (_directory, sidecar, abl_path) = fixture(abl_digest(b"fixture ABL"));
     fs::write(&sidecar, vec![0u8; TZMAP_SIZE - 1]).expect("write truncated sidecar");

--- a/tools/canoe-device/README.canoe.md
+++ b/tools/canoe-device/README.canoe.md
@@ -152,6 +152,19 @@ Guarantees:
 - The BDS write is preceded by a full backup of `efisp` and followed by a
   byte-for-byte comparison of the written region; either failing restores the
   partition. The backup is pulled to the host either way.
+- On each successful install the transaction writes an informational
+  `.canoe.gen` record beside the triplet. Its exact format is
+  `CANOEG1|<bds-sha256>|<boot.efi-sha256>|<gm2p-sha256>|<tzmap-sha256>`.
+  The four digests describe the BDS image and installed files from that run;
+  tree-only installs use `-` for the BDS field. The record is snapshotted and
+  rolled back with the rest of the tree, and nothing refuses to install or boot
+  because of its contents.
+- Before replacing managed files, the transaction enumerates the boot root.
+  Entries outside the managed triplet and backup generation, `BOOTENTRIES`,
+  `tools/`, transaction markers/temporaries and `.canoe.gen` are moved into
+  `.canoe.foreign/` and reported one per line. Existing entries there are never
+  overwritten; a suffixed name is used instead. This move is transactional:
+  a failed install puts the entries back.
 - The preferred-mode record is left untouched unless `--mode N` is passed, in
   which case it is written after a successful install by an on-device
   `mode2_profile mode-write` (aligned read-modify-write, verified by reread)

--- a/tools/canoe-device/canoe_device_install.sh
+++ b/tools/canoe-device/canoe_device_install.sh
@@ -22,17 +22,13 @@
 #
 # Transaction:
 #   1. validate the staged set (sizes are exact contract values)
-#   2. snapshot everything the commit will overwrite: the live triplet, the
-#      existing backup generation, BOOTENTRIES and tools/
-#   3. commit: live -> boot_backup.*, staged -> live
-#   4. install BOOTENTRIES and tools, sync
+#   2. snapshot everything the commit will overwrite: the live triplet,
+#      existing backup generation, BOOTENTRIES, tools/ and .canoe.gen
+#   3. set aside foreign boot-root entries, then commit live -> boot_backup.*,
+#      staged -> live
+#   4. install BOOTENTRIES and tools, write the informational .canoe.gen stamp,
+#      sync
 #   5. optionally back up efisp, write the BDS, verify it byte-for-byte
-#
-# Any failure from step 3 onward restores every snapshotted item, so the boot root
-# is never left with one generation's loader beside another's menu tree. A failed
-# BDS write or verification also restores the partition from the backup taken in
-# step 5. The persist tree is complete and synced before the BDS is written, so an
-# interrupted run never leaves a live BDS pointing at half-installed sidecars.
 #
 # The preferred-mode record is never touched: only the leading len(BDS.efi) bytes
 # of the partition are written, and the record lives 3072 bytes before its end.
@@ -43,6 +39,7 @@ STAGING=${1:-}
 D=${2:-}
 EFISP_DEV=${3:-}
 BACKUP=${4:-}
+STAGING_NAME=${STAGING##*/}
 
 say()  { printf 'canoe-device: %s\n' "$1"; }
 mark() { printf 'CANOE-MARK: %s\n' "$1"; }
@@ -56,6 +53,9 @@ if [ -n "$EFISP_DEV" ] && [ -z "$BACKUP" ]; then
 fi
 
 size_of() { wc -c < "$1" | tr -d ' \n\r'; }
+sha256_file() {
+  sha256sum "$1" 2>/dev/null | cut -d ' ' -f1
+}
 
 # ------------------------------------------------------ 1. validate staged ---
 [ -s "$STAGING/boot.efi" ]       || die "staged boot.efi is missing or empty"
@@ -77,7 +77,7 @@ mkdir -p "$D" "$D/tools" || die "could not create $D"
 # ------------------------------------------- 2. snapshot what commit touches --
 # The menu tree is part of the transaction: a rollback that restored only the
 # triplet would leave the old loader beside the new BOOTENTRIES and tools.
-rm -rf "$D"/.canoe.live.* "$D"/.canoe.oldbak.* "$D/.canoe.oldmenu" || :
+rm -rf "$D"/.canoe.live.* "$D"/.canoe.oldbak.* "$D/.canoe.oldmenu" "$D/.canoe.oldgen" "$D/.canoe.foreign.moves" "$D/.canoe.gen.tmp" || :
 mkdir -p "$D/.canoe.oldmenu" || die "could not create the snapshot directory"
 
 [ -s "$D/boot.efi" ]              && cp -f "$D/boot.efi" "$D/.canoe.live.efi"
@@ -87,6 +87,9 @@ mkdir -p "$D/.canoe.oldmenu" || die "could not create the snapshot directory"
 [ -s "$D/boot_backup.efi.gm2p" ]  && cp -f "$D/boot_backup.efi.gm2p" "$D/.canoe.oldbak.gm2p"
 [ -s "$D/boot_backup.efi.tzmap" ] && cp -f "$D/boot_backup.efi.tzmap" "$D/.canoe.oldbak.tzmap"
 [ -f "$D/BOOTENTRIES" ]           && cp -f "$D/BOOTENTRIES" "$D/.canoe.oldmenu/BOOTENTRIES"
+if [ -e "$D/.canoe.gen" ]; then
+  cp -f "$D/.canoe.gen" "$D/.canoe.oldgen" || die "could not snapshot .canoe.gen"
+fi
 if [ -d "$D/tools" ]; then
   mkdir -p "$D/.canoe.oldmenu/tools"
   for t in "$D"/tools/*; do
@@ -103,6 +106,51 @@ else
 fi
 
 COMMITTED=no
+
+FOREIGN_EXISTED=no
+[ -d "$D/.canoe.foreign" ] && FOREIGN_EXISTED=yes
+
+set_aside_foreign() {
+  foreign_entry=
+  for foreign_entry in "$D"/* "$D"/.[!.]* "$D"/..?*; do
+    [ -e "$foreign_entry" ] || [ -L "$foreign_entry" ] || continue
+    foreign_name=${foreign_entry##*/}
+    case "$foreign_name" in
+      boot.efi|boot.efi.gm2p|boot.efi.tzmap|boot_backup.efi|boot_backup.efi.gm2p|boot_backup.efi.tzmap|BOOTENTRIES|tools|.canoe.gen|.canoe.foreign|.canoe.live.*|.canoe.oldbak.*|.canoe.oldmenu|.canoe.oldgen|.canoe.foreign.moves|.canoe.gen.tmp|"$STAGING_NAME")
+        continue
+        ;;
+    esac
+    if [ ! -d "$D/.canoe.foreign" ]; then
+      mkdir -p "$D/.canoe.foreign" || fail "could not create .canoe.foreign"
+    fi
+    foreign_target="$D/.canoe.foreign/$foreign_name"
+    foreign_suffix=1
+    while [ -e "$foreign_target" ] || [ -L "$foreign_target" ]; do
+      foreign_target="$D/.canoe.foreign/$foreign_name.$foreign_suffix"
+      foreign_suffix=$((foreign_suffix + 1))
+    done
+    foreign_target_name=${foreign_target##*/}
+    printf '%s\t%s\n' "$foreign_name" "$foreign_target_name" >> "$D/.canoe.foreign.moves" ||
+      fail "could not record foreign entry $foreign_name"
+    mv -f "$foreign_entry" "$foreign_target" ||
+      fail "could not set aside foreign entry $foreign_name"
+    say "set aside foreign entry $foreign_name in .canoe.foreign/$foreign_target_name"
+  done
+}
+
+restore_foreign() {
+  [ -f "$D/.canoe.foreign.moves" ] || return 0
+  old_ifs=$IFS
+  IFS='	'
+  while read -r foreign_name foreign_target_name; do
+    [ -n "$foreign_name" ] || continue
+    mv -f "$D/.canoe.foreign/$foreign_target_name" "$D/$foreign_name" || :
+  done < "$D/.canoe.foreign.moves"
+  IFS=$old_ifs
+  if [ "$FOREIGN_EXISTED" = no ]; then
+    rmdir "$D/.canoe.foreign" 2>/dev/null || :
+  fi
+}
 
 restore_pair() {
   [ "$COMMITTED" = no ] && return 0
@@ -156,6 +204,13 @@ restore_pair() {
     done
   fi
 
+  if [ -e "$D/.canoe.oldgen" ]; then
+    cp -f "$D/.canoe.oldgen" "$D/.canoe.gen" || :
+  else
+    rm -f "$D/.canoe.gen"
+  fi
+
+
   sync || :
   mark "pair-restored"
 }
@@ -173,17 +228,20 @@ restore_efisp() {
 }
 
 cleanup() {
-  rm -rf "$D"/.canoe.live.* "$D"/.canoe.oldbak.* "$D/.canoe.oldmenu" 2>/dev/null || :
+  rm -rf "$D"/.canoe.live.* "$D"/.canoe.oldbak.* "$D/.canoe.oldmenu" "$D/.canoe.oldgen" "$D/.canoe.foreign.moves" "$D/.canoe.gen.tmp" 2>/dev/null || :
 }
 
 fail() {
   restore_efisp
+  restore_foreign
   restore_pair
   cleanup
   die "$1"
 }
 
 # ------------------------------------------------------------- 3. commit -----
+set_aside_foreign
+
 COMMITTED=yes
 if [ -s "$D/.canoe.live.efi" ]; then
   cp -f "$D/.canoe.live.efi" "$D/boot_backup.efi" || fail "could not write boot_backup.efi"
@@ -209,11 +267,31 @@ cp -f "$STAGING/BOOTENTRIES" "$D/BOOTENTRIES" || fail "could not install BOOTENT
 if [ -d "$STAGING/tools" ]; then
   for t in "$STAGING"/tools/*; do
     [ -e "$t" ] || continue
+
     cp -f "$t" "$D/tools/" || fail "could not install $(basename "$t")"
   done
 fi
 sync || fail "sync of the persist tree failed"
 mark "tree-synced"
+write_generation() {
+  boot_digest=$(sha256_file "$D/boot.efi")
+  [ -n "$boot_digest" ] || fail "could not hash installed boot.efi"
+  gm2p_digest=$(sha256_file "$D/boot.efi.gm2p")
+  [ -n "$gm2p_digest" ] || fail "could not hash installed boot.efi.gm2p"
+  tzmap_digest=$(sha256_file "$D/boot.efi.tzmap")
+  [ -n "$tzmap_digest" ] || fail "could not hash installed boot.efi.tzmap"
+  bds_field=-
+  if [ -n "$EFISP_DEV" ]; then
+    bds_field=$(sha256_file "$STAGING/BDS.efi")
+    [ -n "$bds_field" ] || fail "could not hash installed BDS.efi"
+  fi
+  printf 'CANOEG1|%s|%s|%s|%s\n' "$bds_field" "$boot_digest" "$gm2p_digest" "$tzmap_digest" > "$D/.canoe.gen.tmp" ||
+    fail "could not write .canoe.gen"
+  mv -f "$D/.canoe.gen.tmp" "$D/.canoe.gen" || fail "could not install .canoe.gen"
+  mark "generation-stamped"
+}
+
+write_generation
 
 # ---------------------------------------------------------------- 5. BDS -----
 if [ -n "$EFISP_DEV" ]; then

--- a/tools/canoe-device/tests/test_canoe_device_install.sh
+++ b/tools/canoe-device/tests/test_canoe_device_install.sh
@@ -15,12 +15,15 @@
 #
 #   1  success with a previous generation: rotation, menu install, BDS verified
 #   2  invalid staged set aborts before touching anything
-#   3  BDS verification failure rolls back the triplet AND the menu tree
+#   3  BDS verification failure rolls back the triplet, menu tree and stamp
 #   4  first install creates no bogus backup
-#   5  failed first install leaves nothing behind
+#   5  failed first install leaves nothing behind, including the stamp
 #   6  commit failure restores everything
 #   7  BDS write failure restores efisp and the pair
-#   8  tree-only mode leaves the block device untouched
+#   8  tree-only mode leaves the block device untouched and stamps `-`
+#   9  foreign file is set aside and reported
+#  10  foreign file is preserved when the destination name collides
+#  11  foreign disclosure rolls back with the transaction
 set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname "$0")/../../.." && pwd)
@@ -31,7 +34,8 @@ trap 'rm -rf "$TMP"' EXIT INT TERM HUP
 fail() { echo "FAIL: $*" >&2; exit 1; }
 pass() { echo "ok - $*"; }
 sha()  { if [ -f "$1" ]; then sha256sum "$1" | cut -c1-12; else echo ABSENT; fi; }
-temps() { find "$1" -maxdepth 1 -name '.canoe.*' -print 2>/dev/null | wc -l | tr -d ' '; }
+sha_full() { sha256sum "$1" | cut -d ' ' -f1; }
+temps() { find "$1" -maxdepth 1 -name '.canoe.*' ! -name '.canoe.gen' ! -name '.canoe.foreign' -print 2>/dev/null | wc -l | tr -d ' '; }
 
 [ -f "$SCRIPT" ] || fail "missing $SCRIPT"
 
@@ -90,6 +94,8 @@ run_install "$ST" "$D" "$DEV" "$BK" || fail "1: transaction failed: $(cat "$ERR"
 [ "$(sha "$D/tools/BLTools.efi")" != "$tool" ] || fail '1: tools/ was not installed'
 [ "$(temps "$D")" = 0 ] || fail '1: snapshot files were left behind'
 [ -s "$BK" ] || fail '1: no efisp backup was taken'
+expected_gen="CANOEG1|$(sha_full "$ST/BDS.efi")|$(sha_full "$D/boot.efi")|$(sha_full "$D/boot.efi.gm2p")|$(sha_full "$D/boot.efi.tzmap")"
+[ "$(cat "$D/.canoe.gen")" = "$expected_gen" ] || fail '1: generation stamp does not describe installed bytes'
 grep -q 'CANOE-MARK: efisp-verified' "$OUT" || fail '1: BDS was not verified'
 pass 'success rotates the generation, installs the menu tree and verifies the BDS'
 
@@ -106,6 +112,7 @@ pass 'an invalid staged set aborts before touching anything'
 
 # ------------------------------------------------------------------ case 3 --
 setup c3 yes 120 256
+printf 'CANOEG1|old-generation\n' > "$D/.canoe.gen"
 OUT="$TMP/c3/out"; ERR="$TMP/c3/err"
 live=$(sha "$D/boot.efi"); back=$(sha "$D/boot_backup.efi")
 menu=$(sha "$D/BOOTENTRIES"); tool=$(sha "$D/tools/BLTools.efi"); dev=$(sha "$DEV")
@@ -115,6 +122,7 @@ if run_install "$ST" "$D" "$DEV" "$BK"; then fail '3: accepted a failed verifica
 grep -q 'verification' "$ERR" || fail '3: wrong failure message'
 [ "$(sha "$D/boot.efi")" = "$live" ] || fail '3: live triplet not restored'
 [ "$(sha "$D/boot_backup.efi")" = "$back" ] || fail '3: backup not restored'
+[ "$(cat "$D/.canoe.gen")" = 'CANOEG1|old-generation' ] || fail '3: generation stamp not restored'
 [ "$(sha "$D/BOOTENTRIES")" = "$menu" ] || fail '3: BOOTENTRIES not restored'
 [ "$(sha "$D/tools/BLTools.efi")" = "$tool" ] || fail '3: tools/ not restored'
 [ "$(sha "$DEV")" = "$dev" ] || fail '3: efisp not restored'
@@ -138,6 +146,7 @@ dev=$(sha "$DEV")
 shadow c5 cmp '#!/bin/sh
 exit 1'
 if run_install "$ST" "$D" "$DEV" "$BK"; then fail '5: accepted a failed verification'; fi
+[ "$(sha "$D/.canoe.gen")" = ABSENT ] || fail '5: generation stamp left behind'
 [ "$(sha "$D/boot.efi")" = ABSENT ] || fail '5: partial boot.efi left behind'
 [ "$(sha "$D/boot_backup.efi")" = ABSENT ] || fail '5: invented a backup'
 [ "$(sha "$D/BOOTENTRIES")" = ABSENT ] || fail '5: left a menu with no loader'
@@ -184,9 +193,47 @@ setup c8 yes 120 256
 OUT="$TMP/c8/out"; ERR="$TMP/c8/err"; SHADOW=""
 new=$(sha "$ST/boot.efi"); dev=$(sha "$DEV")
 run_install "$ST" "$D" || fail "8: tree-only install failed: $(cat "$ERR")"
+[ "$(cut -d '|' -f1 "$D/.canoe.gen")" = 'CANOEG1' ] || fail '8: generation stamp missing'
+[ "$(cut -d '|' -f2 "$D/.canoe.gen")" = '-' ] || fail '8: tree-only stamp has a BDS digest'
 [ "$(sha "$D/boot.efi")" = "$new" ] || fail '8: tree not installed'
 [ "$(sha "$DEV")" = "$dev" ] || fail '8: device written without being asked'
 ! grep -q 'CANOE-MARK: efisp-verified' "$OUT" || fail '8: reported a BDS write'
 pass 'tree-only mode leaves the block device untouched'
+
+# ------------------------------------------------------------------ case 9 --
+setup c9 yes 120 256
+printf 'STALE-CHAINLOAD-TREE' > "$D/stale-chainload.bin"
+OUT="$TMP/c9/out"; ERR="$TMP/c9/err"; SHADOW=""
+run_install "$ST" "$D" || fail "9: foreign-file install failed: $(cat "$ERR")"
+[ ! -e "$D/stale-chainload.bin" ] || fail '9: foreign file remained in the boot root'
+[ "$(cat "$D/.canoe.foreign/stale-chainload.bin")" = STALE-CHAINLOAD-TREE ] ||
+  fail '9: foreign file was not preserved'
+grep -q 'set aside foreign entry stale-chainload.bin' "$OUT" ||
+  fail '9: foreign-file disclosure was not reported'
+pass 'foreign files are set aside and reported'
+
+# ----------------------------------------------------------------- case 10 --
+setup c10 yes 120 256
+mkdir -p "$D/.canoe.foreign"
+printf 'OLD-FOREIGN' > "$D/.canoe.foreign/stale-tree"
+printf 'NEW-FOREIGN' > "$D/stale-tree"
+OUT="$TMP/c10/out"; ERR="$TMP/c10/err"; SHADOW=""
+run_install "$ST" "$D" || fail "10: foreign collision install failed: $(cat "$ERR")"
+[ "$(cat "$D/.canoe.foreign/stale-tree")" = OLD-FOREIGN ] ||
+  fail '10: existing foreign entry was overwritten'
+[ "$(cat "$D/.canoe.foreign/stale-tree.1")" = NEW-FOREIGN ] ||
+  fail '10: colliding foreign entry was not suffixed'
+pass 'foreign files never overwrite an existing set-aside entry'
+# ----------------------------------------------------------------- case 11 --
+setup c11 yes 120 256
+printf 'ROLLBACK-FOREIGN' > "$D/foreign-before-failure"
+OUT="$TMP/c11/out"; ERR="$TMP/c11/err"
+shadow c11 cmp '#!/bin/sh
+exit 1'
+if run_install "$ST" "$D" "$DEV" "$BK"; then fail '11: accepted a failed verification'; fi
+[ "$(cat "$D/foreign-before-failure")" = ROLLBACK-FOREIGN ] ||
+  fail '11: foreign file was not restored on rollback'
+[ ! -e "$D/.canoe.foreign" ] || fail '11: rollback left a new foreign directory'
+pass 'foreign-file disclosure rolls back with the transaction'
 
 echo 'all canoe device-install fixtures passed'

--- a/tools/canoe-host/canoe/build.py
+++ b/tools/canoe-host/canoe/build.py
@@ -154,4 +154,18 @@ def _derive_tzmap(toolkit: Toolkit) -> None:
         "abl_tzmap derive failed",
     )
     _check(run([tool, "validate", toolkit.tzmap]), "abl_tzmap validate failed")
+    _check(
+        run(
+            [
+                tool,
+                "verify",
+                "--sidecar",
+                toolkit.tzmap,
+                "--abl",
+                toolkit.abl_original,
+                "--allow-zero-digest",
+            ]
+        ),
+        "abl_tzmap verify failed",
+    )
     require_exact(toolkit.tzmap, TZMAP_BYTES, "abl_tzmap output")

--- a/tools/canoe-host/canoe/stage.py
+++ b/tools/canoe-host/canoe/stage.py
@@ -18,6 +18,7 @@ from .layout import (
     require_exact,
     require_nonempty,
 )
+from .proc import Completed, run
 from .stage_mode import ModeRequest, set_preferred_mode
 from .stage_report import stage_report
 from .stage_transaction import Context, check, pull_backup, quote, run_transaction
@@ -154,6 +155,36 @@ def _validate_stage(context: Context) -> None:
     note("staged set validated on device")
 
 
+def _check_verify(result: Completed, message: str) -> None:
+    """Fail with `message`, quoting the verifier's diagnosis."""
+    if result.ok:
+        return
+    detail = (result.err or result.out).strip()
+    raise CanoeError(f"{message}: {detail}" if detail else message)
+
+
+def _verify_tzmap(toolkit: Toolkit) -> None:
+    """Verify the staged tzmap against its recorded unpatched ABL loader."""
+    if not toolkit.abl_original.is_file():
+        note("skipping ABL/tzmap consistency check: ABL_original.efi is unavailable")
+        return
+    tool = toolkit.tool("abl_tzmap")
+    _check_verify(
+        run(
+            [
+                tool,
+                "verify",
+                "--sidecar",
+                toolkit.tzmap,
+                "--abl",
+                toolkit.abl_original,
+                "--allow-zero-digest",
+            ]
+        ),
+        "abl_tzmap verify failed",
+    )
+
+
 def _geometry(context: Context, mode: int | None) -> Geometry | None:
     """Read the efisp geometry once, before the transaction, only if it is needed."""
     if not (context.install_bds or mode is not None):
@@ -175,6 +206,7 @@ def _run(argv: Sequence[str]) -> None:
         raise CanoeError("missing canoe_device_install.sh")
     require_exact(toolkit.gm2p, GM2P_BYTES, "boot.efi.gm2p")
     require_exact(toolkit.tzmap, TZMAP_BYTES, "boot.efi.tzmap")
+    _verify_tzmap(toolkit)
     if options.install_bds:
         require_nonempty(
             toolkit.bds, "missing or empty: BDS.efi (use --skip-bds to install the tree only)"

--- a/tools/canoe-host/tests/stubs/abl_tzmap
+++ b/tools/canoe-host/tests/stubs/abl_tzmap
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""abl_tzmap: derive and validate the 256-byte TrustZone map.
+"""abl_tzmap: derive, validate, and verify the 256-byte TrustZone map.
 
 Fixture stand-in for the real toolkit binary. Records its call in $CANOE_TRACE
 so tests can assert the order the driver invokes the pipeline in.
@@ -7,9 +7,11 @@ so tests can assert the order the driver invokes the pipeline in.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import sys
 from pathlib import Path
+
 
 
 def trace(line: str) -> None:
@@ -63,10 +65,44 @@ def validate(argv: list[str]) -> int:
     return 0
 
 
+def verify(argv: list[str]) -> int:
+    sidecar = None
+    abl = None
+    rest = list(argv)
+    while rest:
+        head = rest.pop(0)
+        if head == "--sidecar":
+            sidecar = Path(rest.pop(0))
+        elif head == "--abl":
+            abl = Path(rest.pop(0))
+        elif head == "--allow-zero-digest":
+            continue
+    trace(
+        f"tzmap-verify {sidecar.name if sidecar else '?'} "
+        f"{abl.name if abl else '?'}"
+    )
+    if sidecar is None or abl is None or not sidecar.is_file() or not abl.is_file():
+        sys.stderr.write("abl_tzmap: verify input is missing\n")
+        return 57
+    if BEHAVIOR == "missing-verify":
+        sys.stderr.write("abl_tzmap: verify unavailable\n")
+        return 127
+    if BEHAVIOR == "verify":
+        sidecar_digest = hashlib.sha256(sidecar.read_bytes()).hexdigest()
+        abl_digest = hashlib.sha256(abl.read_bytes()).hexdigest()
+        sys.stderr.write(
+            f"abl_tzmap: AblDigest mismatch: sidecar={sidecar_digest} abl={abl_digest}\n"
+        )
+        return 56
+    return 0
+
+
 if __name__ == "__main__":
     command, *args = sys.argv[1:]
     if command == "derive":
         raise SystemExit(derive(args))
+    if command == "verify":
+        raise SystemExit(verify(args))
     if command == "validate":
         raise SystemExit(validate(args))
     raise SystemExit(55)

--- a/tools/canoe-host/tests/test_build.py
+++ b/tools/canoe-host/tests/test_build.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import hashlib
 from typing import TYPE_CHECKING
 
 import pytest
 
 if TYPE_CHECKING:
     from tests.conftest import FakeToolkit, ToolkitFactory
+
 GM2P_BYTES = 120
 TZMAP_BYTES = 256
 
@@ -43,9 +45,26 @@ def test_build_success_derives_and_validates_the_matching_triplet(toolkit: FakeT
         "validate boot.efi.gm2p",
         "tzmap-derive ABL_original.efi allow=1",
         "tzmap-validate boot.efi.tzmap",
+        "tzmap-verify boot.efi.tzmap ABL_original.efi",
     ]
     assert "\n3. Flash BDS.efi" in result.stdout
     assert "\n4." not in result.stdout
+
+
+def test_build_tzmap_digest_mismatch_names_both_digests(toolkit: FakeToolkit) -> None:
+    # Given a complete fixture toolkit and a verifier that detects a mismatch:
+    _plant_images(toolkit)
+    # When the real launcher runs:
+    result = toolkit.run("canoe_build", STUB_TZMAP="verify")
+
+    # Then the failure identifies both values that were compared.
+    assert result.returncode != 0
+    sidecar_digest = hashlib.sha256(b"T" * TZMAP_BYTES).hexdigest()
+    abl_digest = hashlib.sha256(b"LOADER-FROM-ABL-IMAGE").hexdigest()
+    assert f"sidecar={sidecar_digest}" in result.stderr
+    assert f"abl={abl_digest}" in result.stderr
+    _assert_triplet_absent(toolkit)
+
 
 
 @pytest.mark.parametrize(
@@ -69,6 +88,13 @@ def test_build_success_derives_and_validates_the_matching_triplet(toolkit: FakeT
             "abl_tzmap validate failed",
             id="tzmap-validate",
         ),
+        pytest.param(
+            {"STUB_TZMAP": "missing-verify"},
+            None,
+            "abl_tzmap verify failed",
+            id="tzmap-verify",
+        ),
+        pytest.param({"STUB_TZMAP": "verify"}, None, "abl_tzmap verify failed", id="tzmap-digest"),
         pytest.param({"STUB_TZMAP": "size"}, None, "abl_tzmap output", id="tzmap-size"),
         pytest.param({}, "images/abl.img", "extractfv failed", id="missing-abl"),
     ],

--- a/tools/canoe-host/tests/test_stage.py
+++ b/tools/canoe-host/tests/test_stage.py
@@ -16,12 +16,19 @@ if TYPE_CHECKING:
 
 def _clean_stage(toolkit: FakeToolkit) -> None:
     """Assert the transaction cleanup contract through the fixture surface."""
-    assert not list(toolkit.device.boot_root.glob(".canoe.*"))
+    assert not toolkit.device.boot_root.joinpath(".canoe.stage").exists()
 
 
 def _prepare(toolkit: FakeToolkit) -> None:
     """Install the fixture's valid derived triplet before a stage run."""
     toolkit.plant_triplet()
+
+
+def _prepare_with_loader(toolkit: FakeToolkit) -> None:
+    """Install a triplet and the unpatched loader used to derive its tzmap."""
+    _prepare(toolkit)
+    (toolkit.root / "ABL_original.efi").write_bytes(b"STAGE-ABL")
+
 
 
 def _run_size_probe(
@@ -77,8 +84,37 @@ def test_green_install_commits_tree_bds_and_backup(toolkit: FakeToolkit) -> None
         "BDS.efi"
     )
     assert toolkit.root.joinpath("work/efisp-backup.img").read_bytes() == old_efisp
+
     assert "preferred-mode record was left untouched" in result.stdout
     _clean_stage(toolkit)
+
+
+def test_stage_verifies_tzmap_when_abl_loader_is_available(toolkit: FakeToolkit) -> None:
+    """Given the recorded loader, staging verifies the tzmap before transaction."""
+    _prepare_with_loader(toolkit)
+    result = toolkit.run("canoe_stage")
+
+    assert result.returncode == 0, result.stderr
+    assert "tzmap-verify boot.efi.tzmap ABL_original.efi" in toolkit.trace()
+
+
+def test_stage_rejects_a_tzmap_digest_mismatch_before_transaction(toolkit: FakeToolkit) -> None:
+    """Given a mismatched tzmap, staging stops before the device transaction."""
+    _prepare_with_loader(toolkit)
+    result = toolkit.run("canoe_stage", STUB_TZMAP="verify")
+
+    assert result.returncode != 0
+    assert "abl_tzmap verify failed" in result.stderr
+    assert not toolkit.device.saw("sh /persist/efisp/.canoe.stage/canoe_device_install.sh")
+
+
+def test_stage_skips_tzmap_check_when_abl_loader_is_missing(toolkit: FakeToolkit) -> None:
+    """Given a prepared folder without its loader, staging reports an explicit skip."""
+    _prepare(toolkit)
+    result = toolkit.run("canoe_stage")
+
+    assert result.returncode == 0, result.stderr
+    assert "skipping ABL/tzmap consistency check: ABL_original.efi is unavailable" in result.stdout
 
 
 def test_failed_push_never_invokes_transaction(toolkit: FakeToolkit) -> None:

--- a/wiki/docs/ota.md
+++ b/wiki/docs/ota.md
@@ -65,6 +65,15 @@ for img in os.listdir(img_dir):
 3. Flash these partitions using fastboot
 
 
+## Boot failure symptoms
+
+| Symptom | Likely cause | Recovery |
+|---------|--------------|----------|
+| Black screen after the vendor logo, no fastboot text; the host sees `QUSB_BULK_CID` (EDL 9008) | Pre-ABL failure: the ABL on the active slot cannot run — e.g. a foreign ABL was flashed, or the bootloader swapped onto a slot the module never paired | Authorized EDL flash of the matching current firmware |
+| Bootloader and recovery still work, but the system will not boot | Mismatched or half-installed chain: the BDS in `efisp` and the sidecar set in `persist` come from different generations, and nothing paired them | Re-run the full install or toolkit staging flow as one unit, so `BDS.efi`, `boot.efi`, `.gm2p` and `.tzmap` are all from one generation |
+| Red screen | Verified-boot state refused by the firmware | Boot into recovery and refresh or remove the chain |
+
+
 ## About the module
 
 The module installer and WebUI support both Chinese and English.

--- a/wiki/docs/uninstall.md
+++ b/wiki/docs/uninstall.md
@@ -26,6 +26,35 @@ If the bootloader has been **hardware re-locked** (a real `fastboot flashing loc
    ```bash
    fastboot -w
    ```
+ 
+## Stray reference: no stock fastboot
+
+> **Stray reference page:** this is not part of the main install flow.
+
+If stock fastboot never appears and the only fastboot available is the
+superfastboot served by the BDS, relock and wipe the chain in one session:
+
+1. From the BDS, enter **superfastboot**.
+2. Run:
+
+   ```bash
+   fastboot flashing lock
+   fastboot erase efisp
+   ```
+
+Every lock-state hook in this project deliberately mutates the real
+RPMB/DeviceInfo state to **unlocked** instead of merely swallowing the write;
+that is what keeps red screens away. While the chainloaded ABL is running, the
+device is therefore genuinely unlocked, so the relock must be performed from
+inside superfastboot while it is still reachable.
+
+Keep this order. `fastboot flashing lock` must complete while the chain is
+still present; erasing `efisp` first stops the projection, and there may then
+be no stock fastboot from which to relock. On devices that expose stock
+fastboot, use the [ordinary uninstall path](./uninstall.md#3-uninstall-steps)
+above instead.
+
+
 
 
 ## ⚠️ Important Notes

--- a/wiki/docs/zh/ota.md
+++ b/wiki/docs/zh/ota.md
@@ -65,6 +65,15 @@ for img in os.listdir(img_dir):
 3. 使用 fastboot 刷写这些分区
 
 
+## 启动故障症状对照
+
+| 症状 | 可能原因 | 恢复方式 |
+|------|----------|----------|
+| 厂商 logo 之后黑屏，没有 fastboot 界面；电脑端识别为 `QUSB_BULK_CID`（EDL 9008） | ABL 启动之前就已失败：当前槽位上的 ABL 无法运行——例如刷入了不属于本机的 ABL，或 Bootloader 切换到了模块从未配对过的槽位 | 通过授权 EDL 刷写与设备匹配的当前固件 |
+| Bootloader 和 Recovery 都正常，但系统无法启动 | 启动链不匹配或只装了一半：`efisp` 里的 BDS 与 `persist` 里的 sidecar 来自不同世代，彼此之间没有配对 | 将整条启动链作为整体重装（重装模块或重新走工具包 staging 流程），确保 `BDS.efi`、`boot.efi`、`.gm2p`、`.tzmap` 同属一套 |
+| 红屏 | 固件拒绝了 verified-boot 状态 | 进入 Recovery，刷新或移除启动链 |
+
+
 ## 关于模块
 
 模块安装脚本与 WebUI 均支持中文和英文。

--- a/wiki/docs/zh/uninstall.md
+++ b/wiki/docs/zh/uninstall.md
@@ -31,6 +31,32 @@
    ```bash
    fastboot -w
    ```
+ 
+## 补充参考：没有官方 fastboot
+
+> **孤立参考页面：** 本页不属于主安装流程。
+
+如果设备永远不会出现官方 fastboot，唯一可用的 fastboot 是 BDS 提供的
+superfastboot，请在同一次会话中完成回锁和启动链擦除：
+
+1. 从 BDS 进入 **superfastboot**。
+2. 按以下顺序执行：
+
+   ```bash
+   fastboot flashing lock
+   fastboot erase efisp
+   ```
+
+本项目的所有锁定状态 hook 都会有意将真实的 RPMB/DeviceInfo 状态改写为
+**未锁定**，而不是仅吞掉写入；正是这样才能避免红屏。因此，链式加载的
+ABL 运行期间设备确实处于解锁状态，必须趁 superfastboot 仍可进入时，在其中
+执行回锁。
+
+顺序不可颠倒。`fastboot flashing lock` 必须在启动链仍存在时完成；如果先擦除
+`efisp`，投影会停止，之后可能没有官方 fastboot 可用于回锁。对于确实提供
+官方 fastboot 的设备，请改用上面的[常规卸载步骤](./uninstall.md#3-卸载步骤)。
+
+
 
 
 ## ⚠️ 注意事项


### PR DESCRIPTION
Hardening series from two field failures. Nothing here changes the exploit, the modes, or the lock-state projection.

## What the two reports actually were

**Hard brick (EDL 9008, no fastboot).** Fresh module install → recovery → BDS menu → `Android` → OrangeFox → format data → reboot → vendor logo, black screen, `QUSB_BULK_CID`, no bootloop, no fastboot text. No EDL pull will ever be available. Nothing in this repository sets an active slot, decrements a retry counter, or marks a slot successful, and selecting `Android` only writes the bounded 1 KiB default record. What fits: the first *system* boot failed, the retries drained, the bootloader swapped slots, and the slot it swapped to carried an ABL that cannot run on that device. Fresh install pairs **only** the active slot, so any first-boot failure escalated from "reflash" to "EDL".

**Chainload → canoe upgrade, recoverable.** Bootloader and recovery fine, system will not boot, reverting the older install boots. Shape: canoe's BDS in `efisp` over a persist tree from another generation. The two halves are written by independent steps with no identity handshake, and every fallback on the boot path is silent.

## Commits

| commit | what |
|---|---|
| `abl-tzmap: add verify…` | `AblDigest` has been carried since the map was introduced and was never compared to anything. New `abl_tzmap verify --sidecar --abl [--allow-zero-digest]`; BDS gains an observability-only digest marker in `SfbLoadTzMap`. |
| `ablrepo: record per-image identity…` | `abl.meta` per product (product/model/soc/abl_version/sha256/bytes, `same_image_as`, informational `codename`). README stops claiming a re-patch check that did not exist. Four dirs (CPH2841, OPD2513, PLR110, PMA120) are recorded as sharing one binary — disclosed as a warning sign, not an endorsement. Every unevidenced field is the literal `unknown`. No image added, removed, or modified. |
| `module: gate the ABL downgrade…` | The real fix. Candidate image is extracted+patched and refused unless the GBL patch succeeds; `abl.meta` must agree with the device; **the pair is re-derived after the downgrade** and the install aborts if the flashed ABL still lacks the vulnerability; staged tzmap is verified against the loader from the ABL on flash. The ABL write gets size-fit, snapshot, hash readback and restore-on-mismatch — it was the only firmware write here without them. A committed install now pairs the inactive slot when that slot is not already vulnerable, warning-only. |
| `canoe-device: stamp the installed generation…` | `.canoe.gen` inside the existing transaction (informational; nothing refuses to boot because of it) and unmanaged boot-root entries moved into `.canoe.foreign/`, reported, never deleted, never overwritten. |
| `canoe-host: verify the tzmap sidecar…` | Build fails on a digest mismatch; stage verifies when the ABL is beside the triplet and skips with one explicit line when it is not — a stage the previous release accepted does not start failing. |
| `docs: name the failure signatures…` | Symptom → cause → recovery for EDL/9008-black-screen and for system-won't-boot-with-working-bootloader, both languages. Uninstall documents the superfastboot relock path for devices where stock fastboot never appears, including why `flashing lock` must precede erasing the chain. |

## Deliberately not done

* No anti-rollback gating. SM8850 has no bootchain ARB fuses and AVB ARB is recoverable by a full fastboot/OTA flash.
* No change to lock-state behaviour and **no change to `BLTools`** — the hooks mutating real state to unlocked is the intended red-screen avoidance, and BL Tools is upstream-inherited, so it needs upstream review, not a patch from here.
* No mode-record changes: Mode 1 ↔ Mode 2 differ only in lock projection on OOS-based firmware and the keys are interchangeable, so there is nothing to migrate and mode selection is already enumerated in the BDS.
* No exit-to-ABL path. Verified separately that `SfbBuildMenu` reserves four slots and appends `Enter Fastboot` unconditionally, so superfastboot is already served in every case.
* No upstream-inherited file touched: nothing under `AndroidToolsPkg`, `FastbootLib`, `PartitionTableUpdate`, or generic EDK2 packages. The only UEFI edit is one DEBUG line in this project's own `SuperFbLaunchPolicy.c`. The shipped `BDS.efi` is not rebuilt, so the byte-identical-BDS invariant holds.

## Verification

Every targeted suite touched by this branch, all green:

```
sh targets/magisk_module/tests/test_flows.sh          rc=0
sh targets/magisk_module/tests/test_webui.sh          rc=0
sh tools/canoe-device/tests/test_canoe_device_install.sh  rc=0  (11 fixtures)
python -m pytest tools/canoe-host/tests -q            rc=0  (43 passed)
cargo test --manifest-path tools/abl-tzmap/Cargo.toml rc=0
cargo test --manifest-path tools/mode2-profile/Cargo.toml rc=0
```

New coverage: staging refused when the GBL warning survives a downgrade; candidate image refused when it does not take the patch; ABL write rolled back and reported on a readback mismatch; sidecar/ABL digest mismatch rolling back the pair; inactive-slot pairing skipped when already vulnerable and warning-only on failure; `.canoe.gen` written/restored/removed across rollback and tree-only runs; foreign file set aside, preserved on collision, rolled back; build/stage verify pass, fail, and skip. `abl.meta` self-consistency was checked against the images on disk for all 13 directories (sha256, bytes, committed `abl.sha256`, `same_image_as` symmetry).

Not verified on hardware — no device in this loop. The module path is exercised only through the flow fixtures.

## Merge ordering caveat

The module now requires `abl.meta` for a repo downgrade, and the cloud fallback fetches it from `main`. The bundled copy inside the module ZIP is tried first, so a build cut from this branch works standalone — but **merge this before shipping a module build**, or the cloud fallback will refuse on `main` until the metadata exists there.
